### PR TITLE
Fix schedule and unschedule not updating UI bug

### DIFF
--- a/src/main/java/seedu/planner/logic/commands/ScheduleCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/ScheduleCommand.java
@@ -14,6 +14,7 @@ import seedu.planner.commons.core.Messages;
 import seedu.planner.commons.core.index.Index;
 import seedu.planner.logic.commands.exceptions.CommandException;
 import seedu.planner.logic.commands.result.CommandResult;
+import seedu.planner.logic.commands.result.UiFocus;
 import seedu.planner.logic.commands.util.HelpExplanation;
 import seedu.planner.model.Model;
 import seedu.planner.model.activity.Activity;
@@ -93,7 +94,8 @@ public class ScheduleCommand extends UndoableCommand {
         model.scheduleActivity(dayToEdit, activityWithTimeToAdd);
 
         model.updateFilteredItinerary(PREDICATE_SHOW_ALL_DAYS);
-        return new CommandResult(String.format(MESSAGE_SCHEDULE_ACTIVITY_SUCCESS, dayIndex.getOneBased()));
+        return new CommandResult(String.format(MESSAGE_SCHEDULE_ACTIVITY_SUCCESS, dayIndex.getOneBased()),
+                new UiFocus[]{UiFocus.AGENDA});
     }
 
     @Override

--- a/src/main/java/seedu/planner/logic/commands/UnscheduleCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/UnscheduleCommand.java
@@ -11,6 +11,7 @@ import seedu.planner.commons.core.Messages;
 import seedu.planner.commons.core.index.Index;
 import seedu.planner.logic.commands.exceptions.CommandException;
 import seedu.planner.logic.commands.result.CommandResult;
+import seedu.planner.logic.commands.result.UiFocus;
 import seedu.planner.logic.commands.util.HelpExplanation;
 import seedu.planner.model.Model;
 import seedu.planner.model.day.ActivityWithTime;
@@ -75,7 +76,7 @@ public class UnscheduleCommand extends UndoableCommand {
 
         model.updateFilteredItinerary(PREDICATE_SHOW_ALL_DAYS);
         return new CommandResult(String.format(MESSAGE_UNSCHEDULE_TIME_SUCCESS, activityIndexToUnschedule.getOneBased(),
-                dayIndex.getOneBased()));
+                dayIndex.getOneBased()), new UiFocus[]{UiFocus.AGENDA});
     }
 
     @Override

--- a/src/main/java/seedu/planner/ui/CentralDisplay.java
+++ b/src/main/java/seedu/planner/ui/CentralDisplay.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.Node;

--- a/src/main/java/seedu/planner/ui/CentralDisplay.java
+++ b/src/main/java/seedu/planner/ui/CentralDisplay.java
@@ -62,6 +62,8 @@ public class CentralDisplay extends UiPart<Region> {
 
     private static final String FXML = "CentralDisplay.fxml";
 
+    private final Agenda agenda;
+
     @FXML
     private Accordion sideDisplay;
     @FXML
@@ -94,7 +96,7 @@ public class CentralDisplay extends UiPart<Region> {
         this.dayList = dayList;
 
         // initialising agenda
-        Agenda agenda = new Agenda() {
+        this.agenda = new Agenda() {
             @Override
             public String getUserAgentStylesheet() {
                 return Agenda.class.getResource("/view/" + Agenda.class.getSimpleName() + ".css")
@@ -140,10 +142,10 @@ public class CentralDisplay extends UiPart<Region> {
         tabDisplay.prefWidthProperty().bind(this.getRoot().prefWidthProperty());
 
         // set up listeners that will update the agenda
-        dayList.addListener((ListChangeListener<? super Day>) c -> {
-            updateSkin(agenda);
-            updateAgenda(agenda, dayList);
-        });
+        //dayList.addListener((ListChangeListener<? super Day>) c -> {
+        //    updateSkin(agenda);
+        //    updateAgenda(agenda, dayList);
+        //});
         startDateProperty.addListener((observable, oldValue, newValue) -> {
             updateAgenda(agenda, dayList);
             agenda.setDisplayedLocalDateTime(newValue.atStartOfDay());
@@ -215,6 +217,7 @@ public class CentralDisplay extends UiPart<Region> {
             switch (u) {
             case AGENDA:
                 tabDisplay.getSelectionModel().select(agendaTab);
+                updateAgenda(agenda, dayList);
                 break;
             case INFO:
                 tabDisplay.getSelectionModel().select(infoTab);


### PR DESCRIPTION
Addresses issue https://github.com/AY1920S1-CS2103T-T09-1/main/issues/141

Listener in agenda listens to the list of days. Since day is a list of activity, when the list of activity mutates, agenda fails to receive an update because it only checks on days mutation and not the internal mutation of day.

Temporarily fix the bug by forcing an update to Itinerary when Ui focuses on itinerary.
