### PR TITLE
Set limit on number of days in itinerary to 31

### DIFF
--- a/src/main/java/seedu/planner/logic/commands/AddDayCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/AddDayCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
 import seedu.planner.commons.core.index.Index;
+import seedu.planner.logic.commands.exceptions.CommandException;
 import seedu.planner.logic.commands.result.CommandResult;
 import seedu.planner.logic.commands.result.UiFocus;
 import seedu.planner.logic.commands.util.HelpExplanation;
@@ -25,6 +26,7 @@ public class AddDayCommand extends AddCommand {
     );
 
     public static final String MESSAGE_SUCCESS = "%d day(s) added";
+    public static final String MESSAGE_NUMBER_OF_DAYS_LIMIT_EXCEEDED = "Total number of days exceeds the limit of 31";
 
     private final int toAdd;
     private final Index index;
@@ -57,9 +59,12 @@ public class AddDayCommand extends AddCommand {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
+        int currNumDays = model.getNumberOfDays();
+        if ((currNumDays + toAdd) > 31) {
+            throw new CommandException(MESSAGE_NUMBER_OF_DAYS_LIMIT_EXCEEDED);
+        }
         if (index == null && dayToAdd == null) {
             model.addDays(toAdd);
         } else {

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -212,15 +212,15 @@ public class ParserUtil {
      */
     public static List<Index> parseDaysToSchedule(String days) throws ParseException {
         requireNonNull(days);
-        String[] trimmmedDays = days.trim().split(" ");
-        int numOfDays = trimmmedDays.length;
+        String[] trimmedDays = days.trim().split(" ");
+        int numOfDays = trimmedDays.length;
         List<Index> dayList = new ArrayList<>();
 
         for (int i = 0; i < numOfDays; i++) {
-            if (!Day.isValidDayNumber(trimmmedDays[i])) {
+            if (!Day.isValidDayNumber(trimmedDays[i])) {
                 throw new ParseException(Day.MESSAGE_CONSTRAINTS);
             }
-            dayList.add(parseIndex(trimmmedDays[i]));
+            dayList.add(parseIndex(trimmedDays[i]));
         }
         return dayList;
     }

--- a/src/main/java/seedu/planner/model/Itinerary.java
+++ b/src/main/java/seedu/planner/model/Itinerary.java
@@ -143,6 +143,10 @@ public class Itinerary implements ReadOnlyItinerary {
         return days.getDays(activity);
     }
 
+    public int getNumberOfDays() {
+        return days.getNumberOfDays();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/planner/model/Model.java
+++ b/src/main/java/seedu/planner/model/Model.java
@@ -339,6 +339,8 @@ public interface Model {
 
     void unscheduleActivity(Day day, Index toRemove);
 
+    int getNumberOfDays();
+
     /**
      * Returns an unmodifiable view of the filtered itinerary
      */

--- a/src/main/java/seedu/planner/model/ModelManager.java
+++ b/src/main/java/seedu/planner/model/ModelManager.java
@@ -576,6 +576,11 @@ public class ModelManager implements Model {
         return itinerary.getDays(activity);
     }
 
+    @Override
+    public int getNumberOfDays() {
+        return itinerary.getNumberOfDays();
+    }
+
     //=========== Filtered List Accessors =============================================================
     // ACCOMMODATION FilteredList
     /**

--- a/src/main/java/seedu/planner/model/day/Day.java
+++ b/src/main/java/seedu/planner/model/day/Day.java
@@ -11,8 +11,9 @@ import seedu.planner.model.activity.Activity;
  * Guarantees: timetable is present and not null, field values are validated, immutable.
  */
 public class Day {
-    public static final String MESSAGE_CONSTRAINTS = "Number of days should be an integer greater than 0.";
-    public static final String VALIDATION_REGEX = "^[1-9]\\d*$";
+    public static final String MESSAGE_CONSTRAINTS = "Number of days should be a non-negative integer less "
+            + "than or equal to 31.";
+    public static final String VALIDATION_REGEX = "^(3[01]|[12][0-9]|[1-9])$";
 
     private final Timetable timetable;
 

--- a/src/main/java/seedu/planner/model/day/DayList.java
+++ b/src/main/java/seedu/planner/model/day/DayList.java
@@ -120,6 +120,10 @@ public class DayList implements Iterable<Day> {
         return listOfDays;
     }
 
+    public int getNumberOfDays() {
+        return internalList.size();
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/test/java/seedu/planner/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/AddContactCommandTest.java
@@ -340,6 +340,10 @@ public class AddContactCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        public int getNumberOfDays() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         public void scheduleActivity(Day day, ActivityWithTime toAdd) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
@@ -35,7 +35,6 @@ public class CommandTestUtil {
     public static final String VALID_TAG_SIGHTSEEING = "sightseeing";
     public static final String VALID_TAG_LESSON = "lesson";
 
-
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";


### PR DESCRIPTION
To address issues of adding too many days. https://github.com/AY1920S1-CS2103T-T09-1/main/issues/185, https://github.com/AY1920S1-CS2103T-T09-1/main/issues/176, https://github.com/AY1920S1-CS2103T-T09-1/main/issues/148

Setting an upper limit seems to be fair as the timetable is practically unusable (because it is too small) after adding too many days. It certainly seems overkill to plan for more than 1 month for a trip. Also the audience we are targeting would unlikely go on a trip with many days.